### PR TITLE
Update whisper.cc

### DIFF
--- a/python/cpp/whisper.cc
+++ b/python/cpp/whisper.cc
@@ -133,6 +133,7 @@ namespace ctranslate2 {
           return "WhisperGenerationResult(sequences=" + std::string(py::repr(py::cast(result.sequences)))
             + ", sequences_ids=" + std::string(py::repr(py::cast(result.sequences_ids)))
             + ", scores=" + std::string(py::repr(py::cast(result.scores)))
+            + ", logits=" + std::string(py::repr(py::cast(result.logits)))
             + ", no_speech_prob=" + std::string(py::repr(py::cast(result.no_speech_prob)))
             + ")";
         })


### PR DESCRIPTION
Added logits to WhisperGenerationResult:
readonly documentation was present in register_whisper but no actual return value in WhisperGenerationResult. 
Should solve [Issue #1779](https://github.com/OpenNMT/CTranslate2/issues/1779)